### PR TITLE
const vs var in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const browserSync = require('browser-sync').create();
-const gulp = require('gulp');
+var browserSync = require('browser-sync').create();
+var gulp = require('gulp');
 
 gulp.task('browser-sync', function() {
 	return browserSync.init({


### PR DESCRIPTION
for the gulpfile, whenever I run `gulp watch` I'd get this error:

```
gulpfile.js:3
const browserSync = require('browser-sync').create();
^^^^^
SyntaxError: Use of const in strict mode.
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Liftoff.handleArguments (/usr/local/lib/node_modules/gulp/bin/gulp.js:116:3)
    at Liftoff.<anonymous> (/usr/local/lib/node_modules/gulp/node_modules/liftoff/index.js:192:16)
    at module.exports (/usr/local/lib/node_modules/gulp/node_modules/liftoff/node_modules/flagged-    respawn/index.js:17:3)
    at Liftoff.<anonymous> (/usr/local/lib/node_modules/gulp/node_modules/liftoff/index.js:185:9)
```

Changing types from `const` to `var` solves the problem for me, in fact in the docs, they use `var` too.
see: [browser-sync](http://www.browsersync.io/docs/gulp/), @edzh  would it be alright to merge changes from `const` to `var` or am I the only one with that problem when running `gulp watch`? 
